### PR TITLE
Fix import errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,41 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "plugins": ["simple-import-sort"],
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaVersion": "latest"
+  },
+  "plugins": ["simple-import-sort", "import"],
+  "rules": {
+    "sort-imports": [
+      "error",
+      {
+        "ignoreCase": false,
+        "ignoreDeclarationSort": true,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"],
+        "allowSeparatedGroups": true
+      }
+    ],
+
+    "import/no-unresolved": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          ["sibling", "parent"],
+          "index",
+          "unknown"
+        ],
+        "newlines-between": "never",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,10 @@
 {
   "extends": "next/core-web-vitals",
-  "plugins": ["simple-import-sort"],
+  "plugins": ["simple-import-sort", "import"],
   "parserOptions": {
     "sourceType": "module",
     "ecmaVersion": "latest"
   },
-  "plugins": ["simple-import-sort", "import"],
   "rules": {
     "sort-imports": [
       "error",

--- a/app/components/NotificationSwitch.tsx
+++ b/app/components/NotificationSwitch.tsx
@@ -1,6 +1,6 @@
+import * as Switch from "@radix-ui/react-switch";
 import React from "react";
 import styled from "styled-components";
-import * as Switch from "@radix-ui/react-switch";
 
 const SwitchRoot = styled(Switch.Root)`
   all: unset;

--- a/app/components/NotificationTooltip.tsx
+++ b/app/components/NotificationTooltip.tsx
@@ -1,6 +1,6 @@
-import styled from "styled-components";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import React from "react";
+import styled from "styled-components";
 
 const TooltipContent = styled(Tooltip.Content)`
   width: 16rem;

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -1,5 +1,5 @@
-import styled from "styled-components";
 import { SettingsIcon } from "lucide-react";
+import styled from "styled-components";
 import Modal from "./Modal";
 import SettingsModal from "./SettingsModal";
 

--- a/app/components/SettingsModal.tsx
+++ b/app/components/SettingsModal.tsx
@@ -1,10 +1,10 @@
 import styled from "styled-components";
-import { SettingsProvider } from "../context/SettingsContext";
+import SettingsApplyButton from "./SettingsApplyButton";
 import SettingsHeader from "./SettingsHeader";
-import SettingsTime from "./SettingsTime";
 import SettingsNotification from "./SettingsNotifications";
 import SettingsTheme from "./SettingsTheme";
-import SettingsApplyButton from "./SettingsApplyButton";
+import SettingsTime from "./SettingsTime";
+import { SettingsProvider } from "../context/SettingsContext";
 
 const StyledSettingsModal = styled.div`
   background-color: var(--white);

--- a/app/components/SettingsNotifications.tsx
+++ b/app/components/SettingsNotifications.tsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
-import { useSettingsContext } from "../context/SettingsContext";
-import useLocalStorage from "../hooks/useLocalStorage";
 import Heading from "./Heading";
 import NotificationsSwitch from "./NotificationSwitch";
 import NotificationTooltip from "./NotificationTooltip";
+import { useSettingsContext } from "../context/SettingsContext";
+import useLocalStorage from "../hooks/useLocalStorage";
 
 const StyledSettingsNotifications = styled.div`
   justify-content: space-between;

--- a/app/components/SettingsTheme.tsx
+++ b/app/components/SettingsTheme.tsx
@@ -1,6 +1,3 @@
-import React from "react";
-import styled from "styled-components";
-import * as Select from "@radix-ui/react-select";
 import {
   CheckIcon,
   ChevronDownIcon,
@@ -8,9 +5,12 @@ import {
   MoonIcon,
   SunIcon,
 } from "@radix-ui/react-icons";
+import * as Select from "@radix-ui/react-select";
+import React from "react";
+import styled from "styled-components";
 import Heading from "./Heading";
-import { useSettingsContext } from "../context/SettingsContext";
 import { ThemeValues } from "../context/PomodoroContext";
+import { useSettingsContext } from "../context/SettingsContext";
 
 const StyledSettingsTheme = styled.div`
   justify-content: space-between;

--- a/app/components/SettingsTime.tsx
+++ b/app/components/SettingsTime.tsx
@@ -1,13 +1,13 @@
+import React from "react";
 import styled from "styled-components";
-import { Phase } from "../context/PomodoroContext";
 import Heading from "./Heading";
+import { Phase } from "../context/PomodoroContext";
+import { useSettingsContext } from "../context/SettingsContext";
 import {
   LONG_BREAK_TIME,
   SHORT_BREAK_TIME,
   WORK_TIME,
 } from "../utils/constants";
-import React from "react";
-import { useSettingsContext } from "../context/SettingsContext";
 
 const StyledSettingsTime = styled.div`
   flex-wrap: wrap;

--- a/app/components/Timer.tsx
+++ b/app/components/Timer.tsx
@@ -1,6 +1,6 @@
+import { Pause, Play, RefreshCcw } from "lucide-react";
 import React, { useEffect } from "react";
 import styled from "styled-components";
-import { Pause, Play, RefreshCcw } from "lucide-react";
 import { usePomodoroContext } from "../context/PomodoroContext";
 
 const TimerWrapper = styled.div`

--- a/app/context/PomodoroContext.tsx
+++ b/app/context/PomodoroContext.tsx
@@ -1,14 +1,14 @@
 import React, { createContext, useContext, useReducer } from "react";
+import useLocalStorage from "../hooks/useLocalStorage";
+import useNotification from "../hooks/useNotification";
+import useSettings from "../hooks/useSettings";
+import useTheme from "../hooks/useTheme";
+import useTitle from "../hooks/useTitle";
 import {
   LONG_BREAK_TIME,
   SHORT_BREAK_TIME,
   WORK_TIME,
 } from "../utils/constants";
-import useLocalStorage from "../hooks/useLocalStorage";
-import useTitle from "../hooks/useTitle";
-import useNotification from "../hooks/useNotification";
-import useSettings from "../hooks/useSettings";
-import useTheme from "../hooks/useTheme";
 
 type Phase = "Work" | "Short break" | "Long break";
 const phases: Array<Phase> = ["Work", "Short break", "Long break"];

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
-import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
+import type { Metadata } from "next";
 import StyledComponentsRegistry from "@/lib/registry";
 import GlobalStyles from "./GlobalStyles";
 import "@/app/index.css";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,8 @@ import styled from "styled-components";
 import Heading from "./components/Heading";
 import Menu from "./components/Menu";
 import PomodoroTimer from "./components/PomodoroTimer";
-import { PomodoroProvider } from "./context/PomodoroContext";
 import Settings from "./components/Settings";
+import { PomodoroProvider } from "./context/PomodoroContext";
 
 const Main = styled.main`
   display: flex;

--- a/lib/registry.tsx
+++ b/lib/registry.tsx
@@ -1,7 +1,7 @@
 'use client'
  
-import React, { useState } from 'react'
 import { useServerInsertedHTML } from 'next/navigation'
+import React, { useState } from 'react'
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
  
 export default function StyledComponentsRegistry({

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.1.0",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "typescript": "^5.3.3"
       }
     },
@@ -2382,6 +2383,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.0.tgz",
+      "integrity": "sha512-Y2fqAfC11TcG/WP3TrI1Gi3p3nc8XJyEOJYHyEPEGI/UAgNx6akxxlX74p7SbAQdLcgASKhj8M0GKvH3vq/+ig==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
+    "eslint-plugin-simple-import-sort": "^12.1.0",
     "typescript": "^5.3.3"
   }
 }


### PR DESCRIPTION
Add the simple-import-sort and import eslint plugins to consistently organize the imports.